### PR TITLE
Add gallery for AI Tools and restructure the Deep Learning gallery

### DIFF
--- a/docs/aitools.md
+++ b/docs/aitools.md
@@ -1,0 +1,38 @@
+---
+template: full_width_with_menu.html
+---
+
+# AI Tools
+
+This gallery contains examples of how to use some popular frameworks and libraries for "AI applications",
+including: semantic search, vector databases, large language models, image classification.
+The notebooks are intended to be run using GPU resources.  
+To use GPU resources in SWAN, you need to:
+  
+* Open a ticket with the SWAN team to get access to GPU resources
+* Use SWAN from [https://swan-k8s.cern.ch](https://swan-k8s.cern.ch)
+* Select a software stack with GPU
+  * Note, to get the latest version of the tools used here select the 'bleeding edge' software stack
+
+[<img class="open_in_swan" data-path="DeepLearning-GPU" data-name="SWAN" alt="Open this Gallery in SWAN" src="https://swanserver.web.cern.ch/swanserver/images/badge_swan_white_150.png">][gallery_url]
+
+## Transformers library for text, image, and speech
+This is to illustrate the use of the Transformers library from Hugging Face for LLM, Natural Language Processing (NLP), image, and speech tasks.
+
+* [Transformers for text classification](GPU_and_data/AITools/Transformers_text_example.ipynb)
+* [Transformers for image classifier](GPU_and_data/AITools/Transformers_image_example.ipynb)
+* [Stable diffusion with transformers](GPU_and_data/AITools/Transformers_stable_diffusion_example.ipynb)
+* [Transformers for speech recognition](GPU_and_data/AITools/Transformers_speech_recognition.ipynb)
+
+## Large Language Models
+These notebooks provide examples of how to use LLMs in notebook environments for tests and prototyping
+* [Transformers Large Language Models](GPU_and_data/AITools/Transformers_Large_Language_Models.ipynb)
+* [LangChain LLMs](GPU_and_data/AITools/LangChain_LLMs.ipynb)
+
+## Semantic search with Vector Databases and LLM
+Semantic search allows to query a set of documents. This examples shows how to create
+vector embeddings, store them in a vector database, and perform semantic queries enhanced with LLM.  
+The vector database used in this example is OpenSearch, available as a service for CERN users.
+* [Semantic search with Vector Databases and LLM](GPU_and_data/AITools/LangChain_OpenSearch_semantic_search_with_Vector_DB.ipynb)
+  
+[gallery_url]:https://swan-k8s.cern.ch/user-redirect/download?projurl=https://github.com/cerndb/NotebooksExamples.git

--- a/docs/deeplearning-GPU.md
+++ b/docs/deeplearning-GPU.md
@@ -22,14 +22,6 @@ These notebooks implement a classifier for digit recognition using the MNIST dat
 * [MNIST with PyTorch](GPU_and_data/DeepLearning-GPU/PyTorch_MNIST.ipynb)
 * [MNIST with Pytorch Lightning](GPU_and_data/DeepLearning-GPU/PyTorch_Lightning_MNIST.ipynb)
 
-## Transformers library
-This is to illustrate the use of the Transformers library from Hugging Face for LLM, Natural Language Processing (NLP), image, and speech tasks.
-
-* [Transformers for LLM with Dolly](GPU_and_data/DeepLearning-GPU/Transformers_LLM_Dolly.ipynb)
-* [Transformers for text classification](GPU_and_data/DeepLearning-GPU/Transformers_text_example.ipynb)
-* [Transformers for image classifier](GPU_and_data/DeepLearning-GPU/Transformers_image_example.ipynb)
-* [Stable diffusion with transformers](GPU_and_data/DeepLearning-GPU/Transformers_stable_diffusion_example.ipynb)
-* [Transformers for speech recognition](GPU_and_data/DeepLearning-GPU/Transformers_speech_recognition.ipynb)
 
 ## Deep Learning and basic Data pipelines
 These notebooks provide examples of how to integrate Deep Learning frameworks with some basic data pipelines using Pandas to feed data into the DL training step.  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,3 +30,4 @@ nav:
   - apache_spark.md
   - datatools.md
   - deeplearning-GPU.md
+  - aitools.md


### PR DESCRIPTION
This provides a few examples for ML application tools, in the "AI" topic area, including use of LLMs, transformers for text and image classifications, vector DB use.
Some of the notebooks are new, some are moved from the Deep Learning gallery.